### PR TITLE
feat: file, line numbers in stack traces in release build

### DIFF
--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -29,6 +29,8 @@ C_OPTIONS = \
 	-DXSNAP_VERSION=\"$(XSNAP_VERSION)\" \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
+	-DmxDebug=1 \
+	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \
 	-DmxSloppy=1 \
@@ -43,9 +45,9 @@ C_OPTIONS += \
 	-Wno-misleading-indentation \
 	-Wno-implicit-fallthrough
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -DmxDebug=1 -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -DmxBoundsCheck=1 -O3
+	C_OPTIONS += -O3
 endif
 
 LIBRARIES = -ldl -lm -lpthread

--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -30,6 +30,7 @@ C_OPTIONS = \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
 	-DmxDebug=1 \
+	-DmxNoConsole=1 \
 	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \

--- a/xsnap/makefiles/mac/xsnap-worker.mk
+++ b/xsnap/makefiles/mac/xsnap-worker.mk
@@ -35,7 +35,6 @@ C_OPTIONS = \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
 	-DmxDebug=1 \
-	-DmxNoConsole=1 \
 	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \
@@ -53,7 +52,7 @@ endif
 ifeq ($(GOAL),debug)
 	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -O3
+	C_OPTIONS += -DmxNoConsole=1 -O3
 endif
 
 LIBRARIES = -framework CoreServices

--- a/xsnap/makefiles/mac/xsnap-worker.mk
+++ b/xsnap/makefiles/mac/xsnap-worker.mk
@@ -34,6 +34,8 @@ C_OPTIONS = \
 	-DXSNAP_VERSION=\"$(XSNAP_VERSION)\" \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
+	-DmxDebug=1 \
+	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \
 	-DmxSloppy=1 \
@@ -48,9 +50,9 @@ ifneq ("x$(SDKROOT)", "x")
 	C_OPTIONS += -isysroot $(SDKROOT)
 endif
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -DmxDebug=1 -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -DmxBoundsCheck=1 -O3
+	C_OPTIONS += -O3
 endif
 
 LIBRARIES = -framework CoreServices

--- a/xsnap/makefiles/mac/xsnap-worker.mk
+++ b/xsnap/makefiles/mac/xsnap-worker.mk
@@ -35,6 +35,7 @@ C_OPTIONS = \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
 	-DmxDebug=1 \
+	-DmxNoConsole=1 \
 	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \


### PR DESCRIPTION
This configures `xsnap-worker` more like `xst` and Test262 to take advantage of `sourceURL` support.

ref https://github.com/Agoric/agoric-sdk/issues/2578
