### PR TITLE
feat: integrate TextEncoder / TextDecoder modules

### DIFF
--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -30,7 +30,6 @@ C_OPTIONS = \
 	-DXSNAP_TEST_RECORD=0 \
 	-DmxMetering=1 \
 	-DmxDebug=1 \
-	-DmxNoConsole=1 \
 	-DmxBoundsCheck=1 \
 	-DmxParse=1 \
 	-DmxRun=1 \
@@ -48,7 +47,7 @@ C_OPTIONS += \
 ifeq ($(GOAL),debug)
 	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -O3
+	C_OPTIONS += -DmxNoConsole=1 -O3
 endif
 
 LIBRARIES = -ldl -lm -lpthread

--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -100,10 +100,15 @@ OBJECTS = \
 	$(TMP_DIR)/xsType.o \
 	$(TMP_DIR)/xsdtoa.o \
 	$(TMP_DIR)/xsre.o \
+	$(TMP_DIR)/xsmc.o \
+	$(TMP_DIR)/textdecoder.o \
+	$(TMP_DIR)/textencoder.o \
 	$(TMP_DIR)/xsnapPlatform.o \
 	$(TMP_DIR)/xsnap-worker.o
 
 VPATH += $(SRC_DIR) $(TLS_DIR)
+VPATH += $(MODDABLE)/modules/data/text/decoder
+VPATH += $(MODDABLE)/modules/data/text/encoder
 
 build: $(TMP_DIR) $(BIN_DIR) $(BIN_DIR)/$(NAME)
 

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -43,10 +43,23 @@ static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, xsMachine *t
 static int fxWriteNetString(FILE* outStream, char* prefix, char* buf, size_t len);
 static char* fxWriteNetStringError(int code);
 
+extern void xs_textdecoder(xsMachine *the);
+extern void xs_textdecoder_decode(xsMachine *the);
+extern void xs_textdecoder_get_encoding(xsMachine *the);
+extern void xs_textdecoder_get_ignoreBOM(xsMachine *the);
+extern void xs_textdecoder_get_fatal(xsMachine *the);
+
+extern void xs_textencoder(xsMachine *the);
+extern void xs_textencoder_encode(xsMachine *the);
+extern void xs_textencoder_encodeInto(xsMachine *the);
+
+extern void modInstallTextDecoder(xsMachine *the);
+extern void modInstallTextEncoder(xsMachine *the);
+
 // The order of the callbacks materially affects how they are introduced to
 // code that runs from a snapshot, so must be consistent in the face of
 // upgrade.
-#define mxSnapshotCallbackCount 7
+#define mxSnapshotCallbackCount 15
 xsCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 	xs_issueCommand, // 0
 	xs_print, // 1
@@ -55,6 +68,17 @@ xsCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 	xs_performance_now, // 4
 	xs_currentMeterLimit, // 5
 	xs_resetMeter, // 6
+
+	xs_textdecoder, // 7
+	xs_textdecoder_decode, // 8
+	xs_textdecoder_get_encoding, // 9
+	xs_textdecoder_get_ignoreBOM, // 10
+	xs_textdecoder_get_fatal, // 11
+
+	xs_textencoder, // 12
+	xs_textencoder_encode, // 13
+	xs_textencoder_encodeInto, // 14
+
 	// fx_setInterval,
 	// fx_setTimeout,
 	// fx_clearTimer,
@@ -513,6 +537,9 @@ void xsBuildAgent(xsMachine* machine)
 // 	xsVar(0) = xsNewHostFunction(fx_print, 0);
 // 	xsDefine(xsResult, xsID("log"), xsVar(0), xsDontEnum);
 // 	xsDefine(xsGlobal, xsID("console"), xsResult, xsDontEnum);
+
+	modInstallTextDecoder(the);
+	modInstallTextEncoder(the);
 
 	xsEndHost(machine);
 }


### PR DESCRIPTION
@phoddie this is based on your message of 11:13:27 -0700 today.

1. The functions must be registered with the VM so they can be called by scripts
2. They must be added to the callbacks list for the snapshot.
3. The module's source code needs to be added to the build.

I haven't gotten it to pass our tests yet. Currently, I'm getting:

```
cannot write snapshot /tmp/tmp-11381-TYzf2bXjF7Ft-.xss: Invalid argument
# snapshot: no host instances!
```

ref https://github.com/Agoric/agoric-sdk/issues/3510

cc @kriskowal 