### PR TITLE
fix: harden, lockdown, purify were missing from gxSnapshotCallbacks

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -64,7 +64,7 @@ extern void modInstallBase64(xsMachine *the);
 // The order of the callbacks materially affects how they are introduced to
 // code that runs from a snapshot, so must be consistent in the face of
 // upgrade.
-#define mxSnapshotCallbackCount 17
+#define mxSnapshotCallbackCount 20
 xsCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 	xs_issueCommand, // 0
 	xs_print, // 1
@@ -86,6 +86,10 @@ xsCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 
 	xs_base64_encode, // 15
 	xs_base64_decode, // 16
+
+	fx_lockdown, // 17
+	fx_harden, // 18
+	fx_purify, // 19
 
 	// fx_setInterval,
 	// fx_setTimeout,


### PR DESCRIPTION

symptoms:

```
cannot read snapshot /Users/chrishibbert/agoric-sdk/packages/cosmic-swingset/t1/n0/data/ag-cosmos-chain-state/xs-snapshots/6c4e39bfea710488f4bb9eb10e3e39df39ea2d21a5740139a7696baa8d2aeaf3-load-lDxX2f.xss: Invalid argument
2021-11-11T01:33:29.317Z SwingSet: kernel: ##### KERNEL PANIC: unable to re-create vat v1 #####
```
