### PR TITLE
fix(xsnap-worker): require explicit `$XSBUG_HOST` for debugging

### DIFF
--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -380,8 +380,8 @@ void fxConnect(txMachine* the)
 		}
 	}
 	else {
-		strcpy(name, "localhost");
-		port = 5002;
+		// Require XSBUG_HOST to be set for debugging.
+		return;
 	}
 	memset(&address, 0, sizeof(address));
   	address.sin_family = AF_INET;


### PR DESCRIPTION
I was dismayed to find `xsnap-worker` spinning for a minute before becoming responsive.  As it turns out, my machine was running a different service on `localhost:5002`, and the worker was in a loop trying to connect to it, expecting it was `xsbug`.

To fix `xsnap-worker`, I reset the default `xsbug` port to `-1`, and short-circuit out of the debug connection in that case.  If you need to debug the worker, just explicitly use `XSBUG_HOST=localhost:5002 ./xsnap-worker ...`.
