### PR TITLE
fix(mxDebug): prevent spinning if connection closed

### DIFF
--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -497,18 +497,17 @@ void fxReceive(txMachine* the)
 	if (the->connection != mxNoSocket) {
 #if mxWindows
 		count = recv(the->connection, the->debugBuffer, sizeof(the->debugBuffer) - 1, 0);
-		if (count < 0)
+		if (count <= 0)
 			fxDisconnect(the);
 		else
 			the->debugOffset = count;
 #else
 	again:
 		count = read(the->connection, the->debugBuffer, sizeof(the->debugBuffer) - 1);
-		if (count < 0) {
-			if (errno == EINTR)
-				goto again;
-			else
-				fxDisconnect(the);
+		if (count < 0 && errno == EINTR) {
+			goto again;
+		} else if (count <= 0) {
+			fxDisconnect(the);
 		}
 		else
 			the->debugOffset = count;


### PR DESCRIPTION
See https://github.com/agoric-labs/xsnap-pub/pull/18#issuecomment-1031048857 for steps-to-reproduce.

If the other side of the xsbug connection closes, `xsnap` and `xsnap-worker` would go spinning up 100% CPU.

If `recv` or `read` returns a count of `0`, we should close our end of the connection, too.
