### PR TITLE
feat: flag to enable random memory init

### DIFF
--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -53,6 +53,11 @@ endif
 
 LIBRARIES = -ldl -lm -lpthread
 
+ifeq ($(XSNAP_RANDOM_INIT),1)
+	LIBRARIES += -lbsd
+	C_OPTIONS += -DmxSnapshotRandomInit
+endif
+
 LINK_OPTIONS = -rdynamic
 
 OBJECTS = \

--- a/xsnap/makefiles/lin/xsnap.mk
+++ b/xsnap/makefiles/lin/xsnap.mk
@@ -45,6 +45,11 @@ endif
 
 LIBRARIES = -ldl -lm -lpthread
 
+ifeq ($(XSNAP_RANDOM_INIT),1)
+	LIBRARIES += -lbsd
+	C_OPTIONS += -DmxSnapshotRandomInit
+endif
+
 LINK_OPTIONS = -rdynamic
 
 OBJECTS = \

--- a/xsnap/makefiles/mac/xsnap-worker.mk
+++ b/xsnap/makefiles/mac/xsnap-worker.mk
@@ -55,6 +55,9 @@ ifeq ($(GOAL),debug)
 else
 	C_OPTIONS += -DmxNoConsole=1 -O3
 endif
+ifeq ($(XSNAP_RANDOM_INIT),1)
+	C_OPTIONS += -DmxSnapshotRandomInit
+endif
 
 LIBRARIES = -framework CoreServices
 

--- a/xsnap/makefiles/mac/xsnap.mk
+++ b/xsnap/makefiles/mac/xsnap.mk
@@ -47,6 +47,9 @@ ifeq ($(GOAL),debug)
 else
 	C_OPTIONS += -DmxBoundsCheck=1 -O3
 endif
+ifeq ($(XSNAP_RANDOM_INIT),1)
+	C_OPTIONS += -DmxSnapshotRandomInit
+endif
 
 LIBRARIES = -framework CoreServices
 

--- a/xsnap/sources/xsnapPlatform.h
+++ b/xsnap/sources/xsnapPlatform.h
@@ -47,6 +47,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if mxLinux && mxSnapshotRandomInit
+	#include <bsd/stdlib.h>
+#endif
 #include <string.h>
 #include <time.h>
 #if mxWindows


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/5227

Environment based compile-time option to enable the [XS feature to initialize snapshot memory with random data](https://github.com/Moddable-OpenSource/moddable/compare/public...agoric-labs:mhofman/enable-random-mem-init), allowing to better detect non-deterministic snapshot content.

Requires `libbsd` dependency on Linux.