### PR TITLE
feat: add sent/received timestamps to the metering record

### DIFF
--- a/xsnap/documentation/xsnap-worker.md
+++ b/xsnap/documentation/xsnap-worker.md
@@ -1,0 +1,47 @@
+# xsnap-worker
+
+`sources/xsnap-worker.c` contains a variant of `xsnap` which accepts execution commands over a file descriptor. It is designed to function as a "JS coprocessor", driven by a parent process (which can be written in any language). The parent does a fork+exec of `xsnap-worker`, then writes netstring-formatted commands to the child. The child executes those commands (evaluating JS or delivering the command to a handler function), possibly emitting one or more requests to the parent during execution, then finally finishes the command and writing a status to the parent (including metering information).
+
+By default, the process starts from an empty JS environment (not even SES or `lockdown`). If the child is started with a `-r SNAPSHOTFILENAME` argument, it will start from a previously-written heap snapshot instead.
+
+The launch arguments are:
+
+* `-h`: print this help message
+* `-i <interval>`: set the metering interval (TODO: what does this mean?)
+* `-l <limit>`: limit each delivery to `<limit>` computrons
+* `-p`: print the current meter count before every `print()`
+* `-r <snapshot filename>`: launch from a snapshot file, instead of an empty environment
+* `-s SIZE`: set `parserBufferSize`, in kiB (1024 bytes)
+* `-v`: print the `xsnap` version and exit with rc 0
+* All `argv` strings that do not start with a hyphen are ignored. This allows the parent to include dummy no-op arguments to e.g. label the worker process with a vat ID and name, so admins can use `ps` to distinguish between workers being run for different purposes.
+
+Once started, the process listens on file descriptor 3, and will write to file descriptor 4. The process will perform a blocking read on fd3 until a complete netstring is received. The first character of the body of this netstring indicates what command to execute, with the remainder of the body as the command's payload. The commands are:
+
+* `R` (isReady): writes `netstring(".")` (the body is a single period) to fd4, to acknowledge that the worker is running
+* `e` (evaluate): evaluate the body in the top-level JS environment
+* `?` (command): feed the body (as a JS `String`) to the registered `handleCommand(body)` handler
+  * for both `e` and `?`, execution continues until both the `setImmediate` and the ready-promise-callback queues are empty (the vat is "quiescent")
+  * if evaluation/`handleCommand()` throws an error (and the evaluated code does not catch it), the worker writes `!${toString(err)}` to fd4
+  * if successful, the result should be an ArrayBuffer, or an object with a `.result` property that is an ArrayBuffer
+    * anything else will yield an empty response string
+  * the worker writes a netstring with the following body to fd4:
+    * `.${meterObj}\1${result}`
+    * the `.` prefix indicates success
+    * "meterObj" is a JSON-parseable record, with string keys and numeric values, currently containing `{ currentHeapCount, compute, allocate }`
+      * `currentHeapCount` is the number of bytes allocated by the JS engine (`fxGetCurrentHeapCount()`), it never goes down
+      * `compute` is the number of computrons used during the evaluation/`handleCommand()` (`meterIndex)`
+      * `allocate` is `the->allocatedSpace`
+    * the meterObj is separated from the result by a 0x01 byte (i.e. U+0001 if the body is parsed as UTF-8)
+    * the `result` field is the ArrayBuffer
+* `s` (run script): the body is treated as the filename of a program to run (`xsRunProgramFile`)
+* `m` (load module): the body is treated as the name of a module to load (`xsRunModuleFile`). The module must already be defined, perhaps pre-compiled into the `xsnap` executable.
+  * for both `s` and `m`, an error writes a terse `!` to fd4, and success writes `.${meterObj}\1` (the same success response as for `e`/`?` but with an empty message: just the metering data)
+* `w`: the body is treated as a filename. A GC collection is triggered, and then the JS heap is written to the given filename. The response is `!` or `.${meterObj}\1` as with `s`/`m`
+* all other command characters cause the worker to exit
+
+If at any point the computation exceeds one of the following limits, the process will exit with a non-zero (and non-negative) exit code:
+
+* `E_NOT_ENOUGH_MEMORY` (11): when memory allocation uses more than `allocationLimit` bytes (hard-coded to 2GiB in `xsnapPlatform.c`/`fxCreateMachinePlatform()`)
+* `E_STACK_OVERFLOW` (12): when the stack exceeds the configured limit (hard-coded in `xsnap-worker.c` as `stackCount` to 4096)
+* `E_NO_MORE_KEYS` (16): when the number of "keys" (unique property names) exceeds the limit (hard-coded in `xsnap-worker.c` as `keyCount` to 32000)
+* `E_TOO_MUCH_COMPUTATION` (17): when the computation exceeds the `-l` computron limit

--- a/xsnap/documentation/xsnap-worker.md
+++ b/xsnap/documentation/xsnap-worker.md
@@ -2,15 +2,15 @@
 
 `sources/xsnap-worker.c` contains a variant of `xsnap` which accepts execution commands over a file descriptor. It is designed to function as a "JS coprocessor", driven by a parent process (which can be written in any language). The parent does a fork+exec of `xsnap-worker`, then writes netstring-formatted commands to the child. The child executes those commands (evaluating JS or delivering the command to a handler function), possibly emitting one or more requests to the parent during execution, then finally finishes the command and writing a status to the parent (including metering information).
 
-By default, the process starts from an empty JS environment (not even SES or `lockdown`). If the child is started with a `-r SNAPSHOTFILENAME` argument, it will start from a previously-written heap snapshot instead.
+By default, the process starts from an empty JS environment (for now, you must install SES/`lockdown` yourself, but in the future it is likely to start from an empty SES environment). If the child is started with a `-r SNAPSHOTFILENAME` argument, it will start from a previously-written JS engine snapshot instead.
 
 The launch arguments are:
 
 * `-h`: print this help message
-* `-i <interval>`: set the metering interval (TODO: what does this mean?)
+* `-i <interval>`: set the metering check interval: larger intervals are more efficient but are likely to exceed the execution budget by more computrons
 * `-l <limit>`: limit each delivery to `<limit>` computrons
 * `-p`: print the current meter count before every `print()`
-* `-r <snapshot filename>`: launch from a snapshot file, instead of an empty environment
+* `-r <snapshot filename>`: launch from a JS snapshot file, instead of an empty environment
 * `-s SIZE`: set `parserBufferSize`, in kiB (1024 bytes)
 * `-v`: print the `xsnap` version and exit with rc 0
 * All `argv` strings that do not start with a hyphen are ignored. This allows the parent to include dummy no-op arguments to e.g. label the worker process with a vat ID and name, so admins can use `ps` to distinguish between workers being run for different purposes.
@@ -41,12 +41,12 @@ Once started, the process listens on file descriptor 3, and will write to file d
 * `s` (run script): the body is treated as the filename of a program to run (`xsRunProgramFile`)
 * `m` (load module): the body is treated as the name of a module to load (`xsRunModuleFile`). The module must already be defined, perhaps pre-compiled into the `xsnap` executable.
   * for both `s` and `m`, an error writes a terse `!` to fd4, and success writes `.${meterObj}\1` (the same success response as for `e`/`?` but with an empty message: just the metering data)
-* `w`: the body is treated as a filename. A GC collection is triggered, and then the JS heap is written to the given filename. The response is `!` or `.${meterObj}\1` as with `s`/`m`
+* `w`: the body is treated as a filename. A GC collection is triggered, and then the JS engine state snapshot (the entire virtual machine state: heap, stack, symbol table, etc) is written to the given filename. Then execution continues normally. The response is `!` or `.${meterObj}\1` as with `s`/`m`
 * all other command characters cause the worker to exit
 
 If at any point the computation exceeds one of the following limits, the process will exit with a non-zero (and non-negative) exit code:
 
 * `E_NOT_ENOUGH_MEMORY` (11): when memory allocation uses more than `allocationLimit` bytes (hard-coded to 2GiB in `xsnapPlatform.c`/`fxCreateMachinePlatform()`)
-* `E_STACK_OVERFLOW` (12): when the stack exceeds the configured limit (hard-coded in `xsnap-worker.c` as `stackCount` to 4096)
+* `E_STACK_OVERFLOW` (12): when the JS stack exceeds the configured limit (hard-coded in `xsnap-worker.c` as `stackCount` to 4096). Also, at least for now, when the native stack exceeds a limit.
 * `E_NO_MORE_KEYS` (16): when the number of "keys" (unique property names) exceeds the limit (hard-coded in `xsnap-worker.c` as `keyCount` to 32000)
 * `E_TOO_MUCH_COMPUTATION` (17): when the computation exceeds the `-l` computron limit

--- a/xsnap/documentation/xsnap-worker.md
+++ b/xsnap/documentation/xsnap-worker.md
@@ -36,11 +36,13 @@ Once started, the process listens on file descriptor 3, and will write to file d
         * followed by a pair for each `issueCommand` sent to the parent: the first is the time just before the `issueCommand` is written to fd4, the second is the time just after the response is received on fd3
         * the last is the time just before the `.${meterObj}\1${result}` body is serialized, immediately before it is written back to the parent on fd4 to complete the delivery
       * only the first 100 such timestamps are reported; any later ones are omitted
+      * all times are as reported by unix `gettimeofday()`, with microsecond precision
     * the meterObj is separated from the result by a 0x01 byte (i.e. U+0001 if the body is parsed as UTF-8)
     * the `result` field is the ArrayBuffer
 * `s` (run script): the body is treated as the filename of a program to run (`xsRunProgramFile`)
 * `m` (load module): the body is treated as the name of a module to load (`xsRunModuleFile`). The module must already be defined, perhaps pre-compiled into the `xsnap` executable.
   * for both `s` and `m`, an error writes a terse `!` to fd4, and success writes `.${meterObj}\1` (the same success response as for `e`/`?` but with an empty message: just the metering data)
+  * both `s` and `m` are holdovers from `xsnap.c`, and should be considered deprecated in `xsnap-worker.c`
 * `w`: the body is treated as a filename. A GC collection is triggered, and then the JS engine state snapshot (the entire virtual machine state: heap, stack, symbol table, etc) is written to the given filename. Then execution continues normally. The response is `!` or `.${meterObj}\1` as with `s`/`m`
 * all other command characters cause the worker to exit
 

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -147,6 +147,67 @@ typedef enum {
 	E_TOO_MUCH_COMPUTATION = 17,
 } ExitCode;
 
+#define MAX_TIMESTAMPS 100
+static struct timeval timestamps[MAX_TIMESTAMPS];
+static unsigned int num_timestamps;
+static unsigned int timestamps_overrun;
+static void resetTimestamps() {
+	timestamps_overrun = 0;
+	num_timestamps = 0;
+	// on 64-bit platforms, 'struct timeval' usually needs 8+8=16 bytes
+	//printf("sizeof(time_t): %ld\n", sizeof(time_t));
+	//printf("sizeof(time_suseconts_t): %ld\n", sizeof(suseconds_t));
+}
+static void recordTimestamp() {
+	if (num_timestamps < MAX_TIMESTAMPS) {
+		gettimeofday(&(timestamps[num_timestamps]), NULL);
+		num_timestamps += 1;
+	} else {
+		timestamps_overrun = 1;
+	}
+}
+
+// 2^64 is 18446744073709551616 , which is 20 characters long
+#define DIGITS_FOR_64 20
+// [AA.AA,BB.BB,CC.CC]\0
+static char timestampBuffer[1 + MAX_TIMESTAMPS * (DIGITS_FOR_64 + 1 + DIGITS_FOR_64 + 1) + 1];
+// careless overprovisioning: the fractional part is only 6 digits,
+// not 20, also we never add a trailing comma
+
+static char *renderTimestamps() {
+	// return pointer to static string buffer with '[NN.NN,NN.NN]', or NULL
+	unsigned int size, i, wrote;
+	char *p = timestampBuffer;
+	size = sizeof(timestampBuffer); // holds all numbers, commas, and \0
+	*(p++) = '['; size--;
+	for (i = 0; i < num_timestamps; i++) {
+		// snprintf() returns "the number of characters that would have
+		// been printed if the size were unlimited, not including the
+		// final \0". It writes at most size-1 characters, then writes
+		// the trailing \0.
+		wrote = snprintf(p, size, "%lu.%06lu",
+						 timestamps[i].tv_sec, timestamps[i].tv_usec);
+		p += wrote;
+		size -= wrote;
+		if (size < 2) { // 2 is enough for "]\0", but 1 is not
+			return NULL;
+		}
+		if (i+1 < num_timestamps) {
+			// 2 is also enough for a comma
+			*(p++) = ','; size--;
+		}
+		if (size < 2) { // but the comma might reduce size below 2
+			return NULL;
+		}
+	}
+	if (size < 2) { // paranoia, also in case loop never loops
+		return NULL;
+	}
+	*(p++) = ']'; size--;
+	*(p++) = '\0'; size--;
+	return timestampBuffer;
+}
+
 int main(int argc, char* argv[])
 {
 	int argi;
@@ -289,7 +350,9 @@ int main(int argc, char* argv[])
 			xsUnsignedValue meterIndex = 0;
 			char* nsbuf;
 			size_t nslen;
+			resetTimestamps();
 			int readError = fxReadNetString(fromParent, &nsbuf, &nslen);
+			recordTimestamp(); // delivery received from parent
 			int writeError = 0;
 
 			if (readError != 0) {
@@ -672,19 +735,26 @@ static char* fxReadNetStringError(int code)
 
 static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, xsMachine *the, char* buf, size_t length)
 {
+	recordTimestamp(); // delivery-result sent to parent
+	char *tsbuf = renderTimestamps();
+	if (!tsbuf) {
+		// rendering overrun error, send empty list
+		tsbuf = "[]";
+	}
 	char fmt[] = ("." // OK
 				  "{"
 				  "\"currentHeapCount\":%u,"
 				  "\"compute\":%u,"
-				  "\"allocate\":%u}"
+				  "\"allocate\":%u,"
+				  "\"timestamps\":%s}"
 				  "\1" // separate meter info from result
 				  );
 	char numeral64[] = "12345678901234567890"; // big enough for 64bit numeral
-	char prefix[8 + sizeof fmt + 8 * sizeof numeral64];
+	char prefix[8 + sizeof fmt + 8 * sizeof numeral64 + sizeof timestampBuffer];
 	// Prepend the meter usage to the reply.
 	snprintf(prefix, sizeof(prefix) - 1, fmt,
 			 fxGetCurrentHeapCount(the),
-			 meterIndex, the->allocatedSpace);
+			 meterIndex, the->allocatedSpace, tsbuf);
 	return fxWriteNetString(outStream, prefix, buf, length);
 }
 
@@ -739,6 +809,7 @@ static void xs_issueCommand(xsMachine *the)
 	if (writeError != 0) {
 		xsUnknownError(fxWriteNetStringError(writeError));
 	}
+	recordTimestamp(); // command sent to parent
 
 	// read netstring
 	size_t len;
@@ -746,6 +817,7 @@ static void xs_issueCommand(xsMachine *the)
 	if (readError != 0) {
 		xsUnknownError(fxReadNetStringError(readError));
 	}
+	recordTimestamp(); // command-result received from parent
 
 #if XSNAP_TEST_RECORD
 	fxTestRecord(mxTestRecordJSON | mxTestRecordReply, buf, len);

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -515,7 +515,6 @@ int main(int argc, char* argv[])
 					}
 				}
 				break;
-			case -1:
 			default:
 				done = 1;
 				break;


### PR DESCRIPTION
feat: add sent/received timestamps to the metering record

This does not change the engine behavior, but it augments the metering
results with a "timestamps" field (an array of Numbers), which
captures the times at which:
* the primary delivery message was received
* each syscall ("issueCommand" to parent) was sent
* the response from each syscall was received
* the delivery response was sent (actually just before the metering
results are serialized)

The parent process can correlate these timestamps with similar ones
collected on the parent side, to determine how long it took to send
messages over the pipe. If an unexpected stall is observed, this can
help distinguish between the stall happening on the worker process or
on the parent process.

refs https://github.com/Agoric/agoric-sdk/issues/5152
