### PR TITLE
feat: add --print-pointers to check ASLR status

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -208,6 +208,20 @@ static char *renderTimestamps() {
 	return timestampBuffer;
 }
 
+int data_pointer_value = 1234;
+int bss_pointer_value = 0;
+
+void print_pointers() {
+	char *heap_pointer = malloc(1);
+	int stack_value;
+
+	printf(".text pointer: %p\n", &print_pointers);
+	printf(".data pointer: %p\n", &data_pointer_value);
+	printf(".bss  pointer: %p\n", &bss_pointer_value);
+	printf("heap  pointer: %p\n", heap_pointer);
+	printf("stack pointer: %p\n", &stack_value);
+}
+
 int main(int argc, char* argv[])
 {
 	int argi;
@@ -285,6 +299,10 @@ int main(int argc, char* argv[])
 				xsPrintUsage();
 				return E_BAD_USAGE;
 			}
+		}
+		else if (!strcmp(argv[argi], "--print-pointers")) {
+			print_pointers();
+			return E_SUCCESS;
 		}
 		else if (!strcmp(argv[argi], "-v")) {
 			char version[16];
@@ -616,6 +634,7 @@ void xsPrintUsage()
 	printf("\t-l <limit>: metering limit (default to none)\n");
 	printf("\t-s <size>: parser buffer size, in kB (default to 8192)\n");
 	printf("\t-r <snapshot>: read snapshot to create the XS machine\n");
+	printf("\t--print-pointers: print pointers (to test ASLR)\n");
 	printf("\t-v: print XS version\n");
 }
 


### PR DESCRIPTION
This prints the addresses of things found in the .text/.data/.bss
sections, the heap, and the stack. If two different invocations on the
same system print different values, then ASLR is probably randomizing
the address-space layout.
