### PR TITLE
Improve IPC performance and timing measurement

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -352,7 +352,7 @@ int main(int argc, char* argv[])
 			size_t nslen;
 			resetTimestamps();
 			int readError = fxReadNetString(fromParent, &nsbuf, &nslen);
-			recordTimestamp(); // delivery received from parent
+			recordTimestamp(); // after delivery received from parent
 			int writeError = 0;
 
 			if (readError != 0) {
@@ -734,7 +734,7 @@ static char* fxReadNetStringError(int code)
 
 static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, xsMachine *the, char* buf, size_t length)
 {
-	recordTimestamp(); // delivery-result sent to parent
+	recordTimestamp(); // before sending delivery-result to parent
 	char *tsbuf = renderTimestamps();
 	if (!tsbuf) {
 		// rendering overrun error, send empty list
@@ -800,6 +800,8 @@ static void xs_issueCommand(xsMachine *the)
 		fxAbort(the, xsNotEnoughMemoryExit);
 	}
 
+	recordTimestamp(); // before sending command to parent
+
 	xsGetArrayBufferData(xsArg(0), 0, buf, length);
 	int writeError = fxWriteNetString(toParent, "?", buf, length);
 
@@ -808,7 +810,6 @@ static void xs_issueCommand(xsMachine *the)
 	if (writeError != 0) {
 		xsUnknownError(fxWriteNetStringError(writeError));
 	}
-	recordTimestamp(); // command sent to parent
 
 	// read netstring
 	size_t len;
@@ -816,7 +817,7 @@ static void xs_issueCommand(xsMachine *the)
 	if (readError != 0) {
 		xsUnknownError(fxReadNetStringError(readError));
 	}
-	recordTimestamp(); // command-result received from parent
+	recordTimestamp(); // after command-result received from parent
 
 #if XSNAP_TEST_RECORD
 	fxTestRecord(mxTestRecordJSON | mxTestRecordReply, buf, len);

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -147,7 +147,8 @@ typedef enum {
 	E_TOO_MUCH_COMPUTATION = 17,
 } ExitCode;
 
-#define MAX_TIMESTAMPS 100
+// 250 syscalls
+#define MAX_TIMESTAMPS 502
 static struct timeval timestamps[MAX_TIMESTAMPS];
 static unsigned int num_timestamps;
 static unsigned int timestamps_overrun;
@@ -170,9 +171,10 @@ static void recordTimestamp() {
 // 2^64 is 18446744073709551616 , which is 20 characters long
 #define DIGITS_FOR_64 20
 // [AA.AA,BB.BB,CC.CC]\0
-static char timestampBuffer[1 + MAX_TIMESTAMPS * (DIGITS_FOR_64 + 1 + DIGITS_FOR_64 + 1) + 1];
-// careless overprovisioning: the fractional part is only 6 digits,
-// not 20, also we never add a trailing comma
+static char timestampBuffer[1 + MAX_TIMESTAMPS * (DIGITS_FOR_64 + 1 + 6 + 1) + 1];
+// over provisioning by considering all "sec" values as the max printed length.
+// While the last timestamps does not have a trailing comma, the payload ends
+// with both a closing square bracket and a null byte.
 
 static char *renderTimestamps() {
 	// return pointer to static string buffer with '[NN.NN,NN.NN]', or NULL


### PR DESCRIPTION
Fixes the timestamp measuring code to exclude writing time onto the IPC pipe. This may be important if the write is large and the receiving process hangs.

Increase the number of measured timestamps from 100 to 502 to fit 250 syscalls (2 per syscall + 2 timestamps for the request itself)

Drive by fix of syscall sends to avoid an unnecessary buffer copy.