### PR TITLE
LLVM xray profiling

### DIFF
--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -54,6 +54,13 @@ LINK_OPTIONS = -rdynamic
 
 ifeq ($(GOAL),debug)
 	C_OPTIONS += -g -O1 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+
+	ifeq ($(SANITIZER), xray)
+		# -fxray-instrumentation-bundle=function-entry
+		C_OPTIONS += -fxray-instrument -fxray-instruction-threshold=1
+		LINK_OPTIONS += -fxray-instrument
+	endif
+
 	ifeq ($(SANITIZER), memory)
 		C_OPTIONS += -fsanitize=memory
 		LINK_OPTIONS += -fsanitize=memory

--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -49,8 +49,30 @@ C_OPTIONS = \
 C_OPTIONS += \
 	-Wno-misleading-indentation \
 	-Wno-implicit-fallthrough
+
+LINK_OPTIONS = -rdynamic
+
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+	C_OPTIONS += -g -O1 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
+	ifeq ($(SANITIZER), memory)
+		C_OPTIONS += -fsanitize=memory
+		LINK_OPTIONS += -fsanitize=memory
+
+		# add origin tracking, it adds additional perf cost on top of msan
+		ifdef MSAN_TRACK_ORIGINS
+			C_OPTIONS += -fsanitize-memory-track-origins
+		endif
+	endif
+
+	ifeq ($(SANITIZER), address)
+		C_OPTIONS += -fsanitize=address -fsanitize-recover=address
+		LINK_OPTIONS += -fsanitize=address -fsanitize-recover=address
+	endif
+
+	ifeq ($(SANITIZER), undefined)
+		C_OPTIONS += -fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
+		LINK_OPTIONS += -fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
+	endif
 else
 	C_OPTIONS += -O3
 endif
@@ -61,8 +83,6 @@ ifeq ($(XSNAP_RANDOM_INIT),1)
 	LIBRARIES += -lbsd
 	C_OPTIONS += -DmxSnapshotRandomInit
 endif
-
-LINK_OPTIONS = -rdynamic
 
 OBJECTS = \
 	$(TMP_DIR)/xsAll.o \

--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -64,12 +64,13 @@ ifeq ($(GOAL),debug)
 		endif
 	endif
 
-	ifeq ($(SANITIZER), address)
+	# sanitizers below are compatible - allow bundling them together
+	ifneq (,$(findstring address,$(SANITIZER)))
 		C_OPTIONS += -fsanitize=address -fsanitize-recover=address
 		LINK_OPTIONS += -fsanitize=address -fsanitize-recover=address
 	endif
 
-	ifeq ($(SANITIZER), undefined)
+	ifneq (,$(findstring undefined,$(SANITIZER)))
 		C_OPTIONS += -fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
 		LINK_OPTIONS += -fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
 	endif


### PR DESCRIPTION
This PR adds required flags to compile debug builds with [LLVM Xray](https://llvm.org/docs/XRay.html) to allow profiling, controlled similarly to sanitizers in #35. With xray instrumentation, we can capture traces and use the `llvm-xray` tool to convert the output to different formats. See https://github.com/Agoric/agoric-sdk/issues/7068 for context.

To use (from agoric-sdk):

```sh
cd packages/xsnap
SANITIZER=xray yarn build
# enable instrumentation via env var
XRAY_OPTIONS="xray_mode=xray-basic prepatch_main=true verbosity=1" yarn test
```

Each run of xsnap will print its PID and output:

`==51498==XRay: Log file in 'xray-log.xsnap-worker.zUy3ve'`

We can parse `xray-log.xsnap-worker.zUy3ve` with `llvm-xray`:

```sh
llvm-xray account xray-log.xsnap-worker.zUy3ve --instr_map ./xsnap-native/xsnap/build/bin/lin/debug/xsnap-worker --top=3 --sort=sum --sortorder=dsc
Functions with latencies: 218
   funcid      count [      min,       med,       90p,       99p,       max]       sum  function    
     1434          2 [ 3.126452,  3.129465,  3.129465,  3.129465,  3.129465]  6.255916  xsRun.c:0:0: fxRunID
       97          1 [ 3.129466,  3.129466,  3.129466,  3.129466,  3.129466]  3.129466  xsAPI.c:0:0: fxRunCount
      946          1 [ 3.129462,  3.129462,  3.129462,  3.129462,  3.129462]  3.129462  xsGlobal.c:0:0: fx_eval
```

```sh
llvm-xray stack xray-log.xsnap-worker.zUy3ve --instr_map ./xsnap-native/xsnap/build/bin/lin/debug/xsnap-worker --aggregate-threads 

Unique Stacks: 280
Top 10 Stacks by leaf sum:

Sum: 1696600127
lvl   function                                                            count              sum
#0    main                                                                    0                0
#1    fxRunCount                                                              1       3129466209
#2    fxRunID                                                                 1       3129464668
#3    fx_eval                                                                 1       3129461960
#4    fxRunScript                                                             1       3126494793
#5    fxRunID                                                                 1       3126451793
#6    fxOrdinarySetProperty                                               58649       1696600127

Sum: 1553126385
lvl   function                                                            count              sum
#0    main                                                                    0                0
#1    fxRunCount                                                              1       3129466209
#2    fxRunID                                                                 1       3129464668
#3    fx_eval                                                                 1       3129461960
#4    fxRunScript                                                             1       3126494793
#5    fxRunID                                                                 1       3126451793
#6    fxRunIn                                                             62350       2306815599
#7    fxHasAt                                                             58246       2011622143
#8    fxHasAll                                                            56539       1735811985
#9    fxOrdinaryHasProperty                                               55809       1639403023
#10   fxOrdinaryGetProperty                                               55809       1553126385
```

We can also output formats compatible with various tools, like Chrome Event Viewer/Perfetto (chrome://tracing) to visualize as flame graphs:

```sh
llvm-xray convert xray-log.xsnap-worker.zUy3ve --instr_map ./xsnap-native/xsnap/build/bin/lin/debug/xsnap-worker --symbolize --output-format=trace_event | gzip > xsnap-test-trace.json.gz
```

![image](https://user-images.githubusercontent.com/2566397/224837485-8fd7eb13-e011-422b-9479-c87a972e4389.png)
