### PR TITLE
fix: keyCount compatibility with updated Moddable SDK

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -316,7 +316,8 @@ int main(int argc, char* argv[])
 		256 * 1024,			/* initialHeapCount */
 		128 * 1024,			/* incrementalHeapCount */
 		4096,				/* stackCount */
-		32000,				/* keyCount */
+		32000, 				/* initialKeyCount */
+		8000,				/* incrementalKeyCount */
 		1993,				/* nameModulo */
 		127,				/* symbolModulo */
 		parserBufferSize,	/* parserBufferSize */

--- a/xsnap/sources/xsnap.c
+++ b/xsnap/sources/xsnap.c
@@ -112,7 +112,8 @@ int main(int argc, char* argv[])
 		256 * 1024,			/* initialHeapCount */
 		128 * 1024,			/* incrementalHeapCount */
 		4096,				/* stackCount */
-		32000,				/* keyCount */
+		32000, 				/* initialKeyCount */
+		8000,				/* incrementalKeyCount */
 		1993,				/* nameModulo */
 		127,				/* symbolModulo */
 		parserBufferSize,	/* parserBufferSize */

--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -857,7 +857,8 @@ void fxDumpSnapshot(txMachine* the, txSnapshot* snapshot)
 		fprintf(stderr, "\tinitialHeapCount: %d\n", creation.initialHeapCount);
 		fprintf(stderr, "\tincrementalHeapCount: %d\n", creation.incrementalHeapCount);
 		fprintf(stderr, "\tstackCount: %d\n", creation.stackCount);
-		fprintf(stderr, "\tkeyCount: %d\n", creation.keyCount);
+		fprintf(stderr, "\tinitialKeyCount: %d\n", creation.initialKeyCount);
+		fprintf(stderr, "\tincrementalKeyCount: %d\n", creation.incrementalKeyCount);
 		fprintf(stderr, "\tnameModulo: %d\n", creation.nameModulo);
 		fprintf(stderr, "\tsymbolModulo: %d\n", creation.symbolModulo);
 		fprintf(stderr, "\tparserBufferSize: %d\n", creation.parserBufferSize);


### PR DESCRIPTION
Handle creation options change between Moddable SDK 3.7 and 3.8.7

Refs: https://github.com/Agoric/agoric-sdk/issues/7083