### PR TITLE
support streaming snapshot over fd

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -537,7 +537,17 @@ int main(int argc, char* argv[])
 			#endif
 				path = nsbuf + 1;
 				SnapshotStream stream;
-				stream.file = fopen(path, "wb");
+				if (path[0] == '@') {
+					int fd = atoi(path + 1);
+					int tmpfd = dup(fd);
+					if (tmpfd < 0) {
+						stream.file = NULL;
+					} else {
+						stream.file = fdopen(tmpfd, "ab");
+					}
+				} else {
+					stream.file = fopen(path, "wb");
+				}
 				stream.size = 0;
 				if (stream.file) {
 					snapshot.stream = &stream;

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -339,7 +339,18 @@ int main(int argc, char* argv[])
 	}
 	xsInitializeSharedCluster();
 	if (argr) {
-		snapshot.stream = fopen(argv[argr], "rb");
+		char *path = argv[argr];
+		if (path[0] == '@') {
+			int fd = atoi(path + 1);
+			int tmpfd = dup(fd);
+			if (tmpfd < 0) {
+				snapshot.stream = NULL;
+			} else {
+				snapshot.stream = fdopen(tmpfd, "rb");
+			}
+		} else {
+			snapshot.stream = fopen(path, "rb");
+		}
 		if (snapshot.stream) {
 			machine = xsReadSnapshot(&snapshot, "xsnap", NULL);
 			fclose(snapshot.stream);


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/6363

This introduces support for using an existing fd to read and write the snapshot, allowing streaming to/from the parent process.

A filename starting with `@` will denote a fd to use.
This also changes the internal structure used when reading/writing the snapshot to keep track of the bytes read/written if applicable. (read limits not currently used as it hasn't been necessary).