### PR TITLE
add -n command to emit agoric-upgrade string (agoric-upgrade-10)

### DIFF
--- a/xsnap/documentation/xsnap-worker.md
+++ b/xsnap/documentation/xsnap-worker.md
@@ -13,6 +13,7 @@ The launch arguments are:
 * `-r <snapshot filename>`: launch from a JS snapshot file, instead of an empty environment
 * `-s SIZE`: set `parserBufferSize`, in kiB (1024 bytes)
 * `-v`: print the `xsnap` version and exit with rc 0
+* `-n`: print the agoric-upgrade version and exit with rc 0
 * All `argv` strings that do not start with a hyphen are ignored. This allows the parent to include dummy no-op arguments to e.g. label the worker process with a vat ID and name, so admins can use `ps` to distinguish between workers being run for different purposes.
 
 Once started, the process listens on file descriptor 3, and will write to file descriptor 4. The process will perform a blocking read on fd3 until a complete netstring is received. The first character of the body of this netstring indicates what command to execute, with the remainder of the body as the command's payload. The commands are:

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -327,6 +327,10 @@ int main(int argc, char* argv[])
 			xsVersion(version, sizeof(version));
 			printf("xsnap %s (XS %s)\n", XSNAP_VERSION, version);
 			return E_SUCCESS;
+		}
+		else if (!strcmp(argv[argi], "-n")) {
+			printf("agoric-upgrade-10\n");
+			return E_SUCCESS;
 		} else {
 			xsPrintUsage();
 			return E_BAD_USAGE;


### PR DESCRIPTION
This is a quick hack to embed a distinctive string into the xsnap binary, for use by the agoric `agd` command, to ensure that xsnap has actually been recompiled recently. If a validator somehow forgets to re-compile xsnap, `agd` will notice the mismatch and complain, rather than proceeding with the wrong executable.

Running `xsnap -n` emits this "network upgrade version" string, currently `agoric-upgrade-10`.

In the future, we'll update this string to something new (and perhaps more fine-grained than a once-per-chain-upgrade value) when we make changes to xsnap.

refs https://github.com/Agoric/agoric-sdk/issues/7012