### PR TITLE
Upstream sync part 1

### DIFF
--- a/xsnap/sources/xsnap.c
+++ b/xsnap/sources/xsnap.c
@@ -12,7 +12,7 @@ static void xsReplay(xsMachine* machine);
 static void xs_currentMeterLimit(xsMachine* the);
 static void xs_gc(xsMachine* the);
 static void xs_issueCommand(xsMachine* the);
-static void xs_lockdown(xsMachine *the);
+//static void xs_lockdown(xsMachine *the);
 static void xs_performance_now(xsMachine* the);
 static void xs_print(xsMachine* the);
 static void xs_resetMeter(xsMachine* the);
@@ -564,6 +564,7 @@ void xs_issueCommand(xsMachine* the)
 	fclose(file);
 }
 
+#if 0
 void xs_lockdown(xsMachine *the)
 {
 	fx_lockdown(the);
@@ -608,6 +609,7 @@ void xs_lockdown(xsMachine *the)
 // 	xsResult = xsGet(xsGlobal, xsID("setTimeout"));
 // 	xsCall1(xsGlobal, xsID("harden"), xsResult);
 }
+#endif
 
 void xs_performance_now(xsMachine *the)
 {

--- a/xsnap/sources/xsnap.c
+++ b/xsnap/sources/xsnap.c
@@ -515,7 +515,6 @@ void xs_currentMeterLimit(xsMachine* the)
 
 void xs_gc(xsMachine* the)
 {
-	fprintf(stderr, "gc()\n");
 	xsCollectGarbage();
 }
 

--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -802,8 +802,9 @@ void fxDumpSnapshot(txMachine* the, txSnapshot* snapshot)
 {
 	Atom atom;
 	txByte byte;
-	txID profileID;
 	txCreation creation;
+	txID profileID;
+	txInteger tag;
 	Atom blockAtom;
 	txByte* block = C_NULL;
 // 	txByte* blockLimit;
@@ -851,6 +852,7 @@ void fxDumpSnapshot(txMachine* the, txSnapshot* snapshot)
 		atom.atomSize = ntohl(atom.atomSize) - 8;
 		mxThrowIf((*snapshot->read)(snapshot->stream, &creation, sizeof(txCreation)));
 		mxThrowIf((*snapshot->read)(snapshot->stream, &profileID, sizeof(txID)));
+		mxThrowIf((*snapshot->read)(snapshot->stream, &tag, sizeof(txInteger)));
 		fprintf(stderr, "%4.4s %d\n", (txString)&(atom.atomType), atom.atomSize + 8);
 		fprintf(stderr, "\tinitialChunkSize: %d\n", creation.initialChunkSize);
 		fprintf(stderr, "\tincrementalChunkSize: %d\n", creation.incrementalChunkSize);
@@ -865,6 +867,7 @@ void fxDumpSnapshot(txMachine* the, txSnapshot* snapshot)
 		fprintf(stderr, "\tparserTableModulo: %d\n", creation.parserTableModulo);
 		fprintf(stderr, "\tstaticSize: %d\n", creation.staticSize);
 		fprintf(stderr, "\tprofileID: %d\n", profileID);
+		fprintf(stderr, "\ttag: %d\n", tag);
 
 		mxThrowIf((*snapshot->read)(snapshot->stream, &blockAtom, sizeof(Atom)));
 		blockAtom.atomSize = ntohl(blockAtom.atomSize) - 8;

--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -454,6 +454,8 @@ txID fxFindModule(txMachine* the, txSlot* realm, txID moduleID, txSlot* slot)
 	else
 		slash = path;
 	*slash = 0;
+	if ((c_strlen(path) + c_strlen(name + dot)) >= sizeof(path))
+		mxRangeError("path too long");
 	c_strcat(path, name + dot);
 	return fxNewNameC(the, path);
 }


### PR DESCRIPTION
This cherry picks up a few commits from #44 that do not affect the behavior of xsnap-worker as currently used by agoric-sdk