### PR TITLE
Restore snapshot in existing worker

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -642,6 +642,19 @@ int main(int argc, char* argv[])
 						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
 						c_exit(E_IO_ERROR);
 					}
+					path = nsbuf + 1;
+					snapshot.stream = fopen(path, "rb");
+					if (snapshot.stream) {
+						fxUseSnapshot(machine, &snapshot);
+						fclose(snapshot.stream);
+					}
+					else
+						snapshot.error = errno;
+					if (snapshot.error) {
+						fprintf(stderr, "cannot restore snapshot %s: %s\n",
+								path, strerror(snapshot.error));
+						c_exit(E_IO_ERROR);
+					}
 				} else {
 					// TODO: dynamically build error message including Exception message.
 					int writeError = fxWriteNetString(toParent, "!", "", 0);

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -569,6 +569,39 @@ int main(int argc, char* argv[])
 				}
 				break;
 
+			case 'r':
+			#if XSNAP_TEST_RECORD
+				fxTestRecord(mxTestRecordParam, nsbuf + 1, nslen - 1);
+			#endif
+				path = nsbuf + 1;
+				snapshot.stream = fopen(path, "rb");
+				xsSuspendMetering(machine);
+				if (snapshot.stream) {
+					xsDeleteMachine(machine);
+					machine = xsReadSnapshot(&snapshot, "xsnap", NULL);
+					fclose(snapshot.stream);
+				}	else {
+					snapshot.error = errno;
+				}
+				if (snapshot.error) {
+					fprintf(stderr, "cannot read snapshot %s: %s\n",
+							path, strerror(snapshot.error));
+					// TODO: dynamically build error message including Exception message.
+					int writeError = fxWriteNetString(toParent, "!", "", 0);
+					if (writeError != 0) {
+						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
+					}
+					c_exit(E_IO_ERROR);
+				} else {
+					int writeError = fxWriteOkay(toParent, meterIndex, machine, "", 0);
+					if (writeError != 0) {
+						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
+						c_exit(E_IO_ERROR);
+					}
+				}
+				xsResumeMetering(machine, fxMeteringCallback, interval);
+				break;
+				
 			case 'w':
 			#if XSNAP_TEST_RECORD
 				fxTestRecord(mxTestRecordParam, nsbuf + 1, nslen - 1);

--- a/xsnap/sources/xsnap.h
+++ b/xsnap/sources/xsnap.h
@@ -52,32 +52,7 @@ struct xsSnapshotRecord {
 		(_THE)->firstJump = __HOST_JUMP__.nextJump; \
 		break; \
 	} while(1)
-
-		// xsBooleanValue (*meterCallback)(xsMachine*, xsUnsignedValue) = (_THE)->meterCallback; \
-		// xsUnsignedValue meterInterval = (_THE)->meterInterval; \
-
-#define xsSuspendMetering(_THE) \
-	do { \
-		fxEndMetering(_THE); \
-		(_THE)->stack = __HOST_JUMP__.stack, \
-		(_THE)->scope = __HOST_JUMP__.scope, \
-		(_THE)->frame = __HOST_JUMP__.frame, \
-		(_THE)->code = __HOST_JUMP__.code, \
-		(_THE)->firstJump = __HOST_JUMP__.nextJump;
-
-#define xsResumeMetering(_THE, _CALLBACK, _STEP) \
-		__HOST_JUMP__.nextJump = (_THE)->firstJump; \
-		__HOST_JUMP__.stack = (_THE)->stack; \
-		__HOST_JUMP__.scope = (_THE)->scope; \
-		__HOST_JUMP__.frame = (_THE)->frame; \
-		__HOST_JUMP__.environment = NULL; \
-		__HOST_JUMP__.code = (_THE)->code; \
-		__HOST_JUMP__.flag = 0; \
-		(_THE)->firstJump = &__HOST_JUMP__; \
-		fxBeginMetering(_THE, _CALLBACK, _STEP); \
-		break; \
-	} while(1)
-
+			
 #define xsGetCurrentMeter(_THE) \
 	fxGetCurrentMeter(_THE)
 #define xsSetCurrentMeter(_THE, _VALUE) \
@@ -86,8 +61,6 @@ struct xsSnapshotRecord {
 #else
 	#define xsBeginMetering(_THE, _CALLBACK, _STEP)
 	#define xsEndMetering(_THE)
-	#define xsSuspendMetering(_THE)
-	#define xsResumeMetering(_THE, _CALLBACK, _STEP)
 	#define xsPatchHostFunction(_FUNCTION,_PATCH)
 	#define xsMeterHostFunction(_COUNT) (void)(_COUNT)
 	#define xsGetCurrentMeter(_THE) 0

--- a/xsnap/sources/xsnap.h
+++ b/xsnap/sources/xsnap.h
@@ -96,6 +96,8 @@ struct xsSnapshotRecord {
 
 #define xsReadSnapshot(_SNAPSHOT, _NAME, _CONTEXT) \
 	fxReadSnapshot(_SNAPSHOT, _NAME, _CONTEXT)
+#define xsUseSnapshot(_THE, _SNAPSHOT) \
+	fxUseSnapshot(_THE, _SNAPSHOT)
 #define xsWriteSnapshot(_THE, _SNAPSHOT) \
 	fxWriteSnapshot(_THE, _SNAPSHOT)
 	
@@ -140,6 +142,7 @@ mxImport void fxSetCurrentMeter(xsMachine* the, xsUnsignedValue value);
 #endif
 
 mxImport xsMachine* fxReadSnapshot(xsSnapshot* snapshot, xsStringValue theName, void* theContext);
+mxImport int fxUseSnapshot(xsMachine* the, xsSnapshot* snapshot);
 mxImport int fxWriteSnapshot(xsMachine* the, xsSnapshot* snapshot);
 
 mxImport void fxRunDebugger(xsMachine* the);

--- a/xsnap/sources/xsnap.h
+++ b/xsnap/sources/xsnap.h
@@ -52,7 +52,32 @@ struct xsSnapshotRecord {
 		(_THE)->firstJump = __HOST_JUMP__.nextJump; \
 		break; \
 	} while(1)
-			
+
+		// xsBooleanValue (*meterCallback)(xsMachine*, xsUnsignedValue) = (_THE)->meterCallback; \
+		// xsUnsignedValue meterInterval = (_THE)->meterInterval; \
+
+#define xsSuspendMetering(_THE) \
+	do { \
+		fxEndMetering(_THE); \
+		(_THE)->stack = __HOST_JUMP__.stack, \
+		(_THE)->scope = __HOST_JUMP__.scope, \
+		(_THE)->frame = __HOST_JUMP__.frame, \
+		(_THE)->code = __HOST_JUMP__.code, \
+		(_THE)->firstJump = __HOST_JUMP__.nextJump;
+
+#define xsResumeMetering(_THE, _CALLBACK, _STEP) \
+		__HOST_JUMP__.nextJump = (_THE)->firstJump; \
+		__HOST_JUMP__.stack = (_THE)->stack; \
+		__HOST_JUMP__.scope = (_THE)->scope; \
+		__HOST_JUMP__.frame = (_THE)->frame; \
+		__HOST_JUMP__.environment = NULL; \
+		__HOST_JUMP__.code = (_THE)->code; \
+		__HOST_JUMP__.flag = 0; \
+		(_THE)->firstJump = &__HOST_JUMP__; \
+		fxBeginMetering(_THE, _CALLBACK, _STEP); \
+		break; \
+	} while(1)
+
 #define xsGetCurrentMeter(_THE) \
 	fxGetCurrentMeter(_THE)
 #define xsSetCurrentMeter(_THE, _VALUE) \
@@ -61,6 +86,8 @@ struct xsSnapshotRecord {
 #else
 	#define xsBeginMetering(_THE, _CALLBACK, _STEP)
 	#define xsEndMetering(_THE)
+	#define xsSuspendMetering(_THE)
+	#define xsResumeMetering(_THE, _CALLBACK, _STEP)
 	#define xsPatchHostFunction(_FUNCTION,_PATCH)
 	#define xsMeterHostFunction(_COUNT) (void)(_COUNT)
 	#define xsGetCurrentMeter(_THE) 0


### PR DESCRIPTION
This combines the original [load snapshot command I explored last year](https://github.com/agoric-labs/xsnap-pub/commit/6e9c1574ad7d267eb3bab6b9ac046d6b17b8b6f0), with [`fxUseSnapshot`](https://github.com/agoric-labs/xsnap-pub/pull/44/commits/390adc8689e82cde5c9b1adaffda1730f0c7fc47) from #44 to create a new "restore" command that reads a snapshot from a file or std pipe.

I'm actually not sure if the snapshot restored like this must be the same as the one that was previously written out. Regardless, this may be an option to reload the snapshot in the same process. (It may be interesting if this can be another snapshot entirely as a sort of worker process pool)

Since agoric-sdk currently [creates a new worker process and streams the snapshot to it](https://github.com/Agoric/agoric-sdk/pull/7561) as it's being created, it's likely less performant to use the same process.

While there are 3 commits in this PR, it's only for historical purposes and meant to be squashed.