### PR TITLE
feat: rebuild on external extra dep change

### DIFF
--- a/xsnap/makefiles/lin/xsnap-worker.mk
+++ b/xsnap/makefiles/lin/xsnap-worker.mk
@@ -7,6 +7,8 @@ ifneq ($(VERBOSE),1)
 MAKEFLAGS += --silent
 endif
 
+EXTRA_DEPS =
+
 # MODDABLE = $(CURDIR)/../../moddable
 BUILD_DIR = $(CURDIR)/../../build
 TLS_DIR = $(CURDIR)/../../sources
@@ -142,6 +144,7 @@ $(OBJECTS): $(SRC_DIR)/xsAll.h
 $(OBJECTS): $(SRC_DIR)/xsScript.h
 $(OBJECTS): $(SRC_DIR)/xsSnapshot.h
 $(OBJECTS): $(INC_DIR)/xs.h
+$(OBJECTS): $(EXTRA_DEPS)
 $(TMP_DIR)/%.o: %.c
 	@echo "#" $(NAME) $(GOAL) ": cc" $(<F)
 	$(CC) $< $(C_OPTIONS) -c -o $@

--- a/xsnap/makefiles/mac/xsnap-worker.mk
+++ b/xsnap/makefiles/mac/xsnap-worker.mk
@@ -7,6 +7,8 @@ ifneq ($(VERBOSE),1)
 MAKEFLAGS += --silent
 endif
 
+EXTRA_DEPS =
+
 # MODDABLE = $(CURDIR)/../../moddable
 BUILD_DIR = $(CURDIR)/../../build
 TLS_DIR = $(CURDIR)/../../sources
@@ -151,6 +153,7 @@ $(OBJECTS): $(SRC_DIR)/xsAll.h
 $(OBJECTS): $(SRC_DIR)/xsScript.h
 $(OBJECTS): $(SRC_DIR)/xsSnapshot.h
 $(OBJECTS): $(INC_DIR)/xs.h
+$(OBJECTS): $(EXTRA_DEPS)
 $(TMP_DIR)/%.o: %.c
 	@echo "#" $(NAME) $(GOAL) ": cc" $(<F)
 	$(CC) $< $(C_OPTIONS) -c -o $@

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -338,7 +338,7 @@ int main(int argc, char* argv[])
 			return E_SUCCESS;
 		}
 		else if (!strcmp(argv[argi], "-n")) {
-			printf("agoric-upgrade-10\n");
+			printf("deprecated\n");
 			return E_SUCCESS;
 		} else {
 			xsPrintUsage();

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -17,6 +17,9 @@
 #define SNAPSHOT_SIGNATURE "xsnap 1"
 #ifndef XSNAP_VERSION
 # error "You must define XSNAP_VERSION in the right Makefile"
+#else
+// Allows grepping the binary's strings for the version: strings xsnap-worker | grep xsnap_version
+char *VERSION = "xsnap_version: " XSNAP_VERSION;
 #endif
 
 #ifndef XSNAP_TEST_RECORD


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/9614

Add an `EXTRA_DEPS` environment to the makefile to enable agoric-sdk to trigger a rebuild if some env options change like `XSNAP_VERSION` or `CC`.

Drive-by deprecation of the `-n` command since the agoric-sdk PR will get rid of it in favor of checking the `XSNAP_VERSION` already embedded in `-v`

Tested by building both manually invoking the makefile with and without the `EXTRA_DEPS` set, and through the build script changed in agoric-sdk.

