### PR TITLE
Make xsnap-worker log a simple message to stderr when netstring protocol is broken due to parent exit or closed/broken pipes.

### DIFF
--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -931,7 +931,13 @@ static void xs_issueCommand(xsMachine *the)
 	size_t len;
 	int readError = fxReadNetString(fromParent, &buf, &len);
 	if (readError != 0) {
-		xsUnknownError(fxReadNetStringError(readError));
+		char * errorMessage;
+		if (feof(fromParent)) {
+			errorMessage = "Got EOF on netstring read. Has parent died?";
+		} else {
+			errorMessage = fxReadNetStringError(readError);
+		}
+		xsUnknownError(errorMessage);
 	}
 	recordTimestamp(); // after command-result received from parent
 

--- a/xsnap/sources/xsnap-worker.c
+++ b/xsnap/sources/xsnap-worker.c
@@ -58,6 +58,7 @@ static char* fxReadNetStringError(int code);
 static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, xsMachine *the, char* buf, size_t len);
 static int fxWriteNetString(FILE* outStream, char* prefix, char* buf, size_t len);
 static char* fxWriteNetStringError(int code);
+static void fxSigPipeHandler(int sigNum);
 
 extern xsIntegerValue fxGetCurrentHeapCount(xsMachine* the);
 
@@ -254,6 +255,14 @@ static char *renderTimestamps() {
 	return timestampBuffer;
 }
 
+static void fxSigPipeHandler(int sigNum)
+{
+	if (sigNum == SIGPIPE) {
+		fprintf(stderr, "Caught SIGPIPE. Has parent died?\n");
+		c_exit(E_IO_ERROR);
+	}
+}
+
 int main(int argc, char* argv[])
 {
 	int argi;
@@ -396,6 +405,9 @@ int main(int argc, char* argv[])
 		machine = xsCreateMachine(creation, "xsnap", NULL);
 		xsBuildAgent(machine);
 	}
+
+	signal(SIGPIPE, fxSigPipeHandler);
+
 	if (!(fromParent = fdopen(3, "rb"))) {
 		fprintf(stderr, "fdopen(3) from parent failed\n");
 		c_exit(E_IO_ERROR);
@@ -931,13 +943,11 @@ static void xs_issueCommand(xsMachine *the)
 	size_t len;
 	int readError = fxReadNetString(fromParent, &buf, &len);
 	if (readError != 0) {
-		char * errorMessage;
 		if (feof(fromParent)) {
-			errorMessage = "Got EOF on netstring read. Has parent died?";
-		} else {
-			errorMessage = fxReadNetStringError(readError);
+			fprintf(stderr, "Got EOF on netstring read. Has parent died?\n");
+			c_exit(E_IO_ERROR);
 		}
-		xsUnknownError(errorMessage);
+		xsUnknownError(fxReadNetStringError(readError));
 	}
 	recordTimestamp(); // after command-result received from parent
 


### PR DESCRIPTION
ref: [Agoric/agoric-sdk #4103](https://github.com/Agoric/agoric-sdk/issues/4103)

In this change we add an explicit handling of EOF and SIGPIPE conditions by the xsnap-worker in places when it attempts to read/write a response from/to the parent, but finds itself unable to do so due to broken pipes (ex: parent crash/exit). Previously, the worker would throw an error as an exception into the JS environment on EOF condition and take default action on SIGPIPE (immediate exit). However, throwing an error to JS does not produce any usable diagnostics since the normal error reporting relies on the pipes to be operational, leading to a quiet exit with zero diagnostic trace left behind.

With this change xsnap-worker will log to its own stderr `Caught SIGPIPE. Has parent died?` when it gets a SIGPIPE on write or `Got EOF on netstring read. Has parent died?` when detecting an EOF condition on read before exiting.

A separate PR will be submitted against Agoric/agoric-sdk with corresponding automated test cases.