### PR TITLE
feat: Increase the->allocationLimit to 4GB

### DIFF
--- a/xsnap/sources/xsnapPlatform.c
+++ b/xsnap/sources/xsnapPlatform.c
@@ -291,7 +291,7 @@ void fxCreateMachinePlatform(txMachine* the)
 	// the->allocationLimit = 10 * measured_max;
 
 	size_t GB = 1024 * 1024 * 1024;
-	the->allocationLimit = 2 * GB;
+	the->allocationLimit = 4 * GB;
 }
 
 void fxDeleteMachinePlatform(txMachine* the)


### PR DESCRIPTION
refs: #55

This change is requested in response to https://github.com/Agoric/agoric-sdk/issues/10841

A heap limit is hardcoded to 2GB in [xsnapPlatform.c:294](https://github.com/agoric-labs/xsnap-pub/blob/105bc6862050695b1723fa76df91564fe8111a37/xsnap/sources/xsnapPlatform.c#L294) needs to be raised to 4GB as a workaround so Emerynet can be re-started and upgraded to a release with actual fix for the heap leak.